### PR TITLE
Prepare for a single branch on gerrit

### DIFF
--- a/util/git-hooks/commit-msg
+++ b/util/git-hooks/commit-msg
@@ -44,11 +44,10 @@ add_ChangeId() {
 		return
 	fi
 
-	# *Do* add Change-Id to temp commits (original code bails out here)
-	# if echo "$clean_message" | head -1 | grep -q '^\(fixup\|squash\)!'
-	# then
-	# 	return
-	# fi
+	if echo "$clean_message" | head -1 | grep -q '^\(fixup\|squash\)!'
+	then
+		return
+	fi
 
 	if test "false" = "`git config --bool --get gerrit.createChangeId`"
 	then

--- a/util/git-hooks/pre-push
+++ b/util/git-hooks/pre-push
@@ -19,57 +19,11 @@
 remote="$1"
 url="$2"
 
-zero=0000000000000000000000000000000000000000
-
 upstream_pattern="github\.com.flashrom/flashrom(\.git)?|flashrom\.org.git/flashrom(\.git)?"
 
-# Only care about the upstream repositories
-if echo "$url" | grep -q -v -E "$upstream_pattern" ; then
-	exit 0
+# We use gerrit only and don't want direct pushes
+if echo "$url" | grep -q -E "$upstream_pattern" ; then
+	exit 1
 fi
-
-while read local_ref local_sha remote_ref remote_sha ; do
-
-	# Only allow the stable and staging branches as well as versioned stable branches (e.g., 0.0.x).
-	# The matching expression's RE is always anchored to the first character (^ is undefined).
-	# The outer parentheses are needed to print out the whole matched string.
-	version=$(expr ${remote_ref#*refs/heads/} : '\(\([0-9]\+\.\)\{2,\}x\)$')
-	if [ "$remote_ref" != "refs/heads/staging" ] && \
-	   [ "$remote_ref" != "refs/heads/stable" ] && \
-	   [ -z "$version" ]; then
-		echo "Feature branches not allowed ($remote_ref)." >&2
-		exit 1
-	fi
-
-	if [ "$local_sha" = $zero ]; then
-		echo "Deletion of branches is prohibited." >&2
-		exit 1
-	fi
-
-	# Check for Signed-off-by and Acked-by
-	commit=$(git rev-list -n 1 --all-match --invert-grep -E \
-		--grep '^Signed-off-by: .+ <.+@.+\..+>$' \
-		--grep '^Acked-by: .+ <.+@.+\..+>$' \
-		"$remote_sha..$local_sha")
-	if [ -n "$commit" ]; then
-		echo "Commit $local_sha in $local_ref is missing either \"Signed-off-by\"" \
-			" or \"Acked-by\" lines, not pushing." >&2
-		exit 1
-	fi
-
-	# Make _really_ sure we do not rewrite history of any head/branch
-	if [ "${remote_ref#*refs/heads/}" != "$remote_ref" ]; then
-		nonreachable=$(git rev-list $remote_sha ^$local_sha | head -1)
-		if [ -n "$nonreachable" ]; then
-			echo "Only fast-forward pushes are allowed on branches." >&2
-			echo "At least $nonreachable is not included in $remote_sha while pushing to " \
-			     "$remote_ref" >&2
-			exit 1
-		fi
-	fi
-
-	# FIXME: check commit log format (subject without full stop at the end etc).
-	# FIXME: do buildbot checks if authorized?
-done
 
 exit 0


### PR DESCRIPTION
Discourage all direct pushes to the upstream repositories, no matter the
branch. Also, skip adding Change-Ids to fixup! and squash! commits.

Change-Id: I13aa478edd200ce85da86962e4f94f7ac446b05f
Signed-off-by: Nico Huber <nico.h@gmx.de>
Reviewed-on: https://review.coreboot.org/22330
Tested-by: build bot (Jenkins) <no-reply@coreboot.org>
Reviewed-by: Stefan Reinauer <stefan.reinauer@coreboot.org>